### PR TITLE
feat: test closest region logic

### DIFF
--- a/packages/mcp-server-supabase/src/regions.ts
+++ b/packages/mcp-server-supabase/src/regions.ts
@@ -12,6 +12,7 @@ export type Location = {
 };
 
 export const EARTH_RADIUS = 6371; // in kilometers
+export const TRACE_URL = 'https://www.cloudflare.com/cdn-cgi/trace';
 
 export const COUNTRY_COORDINATES = {
   AF: { lat: 33, lng: 65 },
@@ -387,7 +388,7 @@ export function getClosestAwsRegion(location: Location) {
  * Fetches the user's country code based on their IP address.
  */
 export async function getCountryCode() {
-  const response = await fetch('https://www.cloudflare.com/cdn-cgi/trace');
+  const response = await fetch(TRACE_URL);
   const data = await response.text();
   const info = parseKeyValueList(data);
   const countryCode = info['loc'];


### PR DESCRIPTION
When you create a project via management API, you must choose a region. We added logic that will auto-choose a region if left undefined based on the user's location, but this was never unit tested. This PR adds those tests.

The implementation uses the same logic as the Supabase dashboard:
1. Fetch Cloudflare's [trace route](https://www.cloudflare.com/cdn-cgi/trace) to get country code
2. Map the returned country code to lat/lng coordinates
3. Calculate the distance from this location to each AWS region using the [Haversine formula](https://en.wikipedia.org/wiki/Haversine_formula)
4. Pick the closest region